### PR TITLE
fix error handling

### DIFF
--- a/megacli/__init__.py
+++ b/megacli/__init__.py
@@ -37,10 +37,12 @@ class MegaCLI:
     """
     proc = subprocess.Popen("{0} {1} -NoLog".format(self.cli_path, cmd), shell = True, stdout = subprocess.PIPE, stderr = subprocess.PIPE)
     out, err = proc.communicate()
-    if isinstance(out, bytes):
+
+    # MegaCLI sends errors to stdout, not stderr.
+    if proc.returncode and isinstance(err, bytes):
+      err = out.decode(errors="ignore")
+    elif isinstance(out, bytes):
       out = out.decode(errors="ignore")
-    if isinstance(err, bytes):
-      err = err.decode(errors="ignore")
 
     if proc.returncode:
       ex = MegaCLIError(err.rstrip())


### PR DESCRIPTION
Hello,

I've changed exception logic.
Because MegaCLI 8.07.14 sends errors to stdout, not stderr.

```
server1 : /opt/scripts/sbin/ [55] # MegaCli64 -v
      MegaCLI SAS RAID Management Tool  Ver 8.07.14 Dec 16, 2013

    (c)Copyright 2013, LSI Corporation, All Rights Reserved.

Exit Code: 0x00
```

```python3
>>> MEGACLI_PATH
'/opt/dir/sbin/MegaCli64'
>>> proc = subprocess.Popen(MEGACLI_PATH + ' -adpbbucmd -aall', shell = True, stdout = subprocess.PIPE, stderr = subprocess.PIPE)
>>> out, err = proc.communicate()
>>> out
b'\r                                     \nAdapter 0: Get BBU Design Info Failed.\n\nFW error description: \n The requested operation cannot be completed due to a hardware error (I2C).  \n\nExit Code: 0x37\n'
>>> err
b''
```

```
server1 : /opt/scripts/ [0] # MegaCli64 -AdpBbuCmd  -aAll 1>/dev/null 2>&1
server1 : /opt/scripts/ [55] # MegaCli64 -AdpBbuCmd  -aAll 
                                     
Adapter 0: Get BBU Design Info Failed.

FW error description: 
 The requested operation cannot be completed due to a hardware error (I2C).  

Exit Code: 0x37
server1 : /opt/scripts/ [55] # 
```


Regards